### PR TITLE
Chat sessions

### DIFF
--- a/Doc/Architecture.md
+++ b/Doc/Architecture.md
@@ -32,9 +32,10 @@ The solution file is `LocalWinAI.slnx` at the repository root.
 ┌──────────────────────────────────────────────────────────────────────┐
 │   Application                                                        │
 │  IChatService / ChatService          IUsageAggregateService          │
+│  IChatSessionManager / ChatSessionManager                            │
 │  ChatPageViewModel                   StatisticsPageViewModel         │
-│  ObservableChatMessage               UsageAggregates / ToolStats     │
-│  SettingsPageViewModel               DayStats / ToolStatRow          │
+│  ObservableChatMessage               ChatSessionSummaryViewModel     │
+│  UsageAggregates / ToolStats         DayStats / ToolStatRow          │
 └──────────────────────────────┬───────────────────────────────────────┘
                                │
                                ▼
@@ -43,6 +44,7 @@ The solution file is `LocalWinAI.slnx` at the repository root.
                │  WindowsLanguageModelService          │
                │  NamedPipeInferenceServer             │
                │  ClaudeCodeSettingsService            │
+               │  ChatSessionRepository (→ sessions/)  │
                │  UsageTracker (→ usage.ndjson)        │
                │  UsageAggregateService (FileWatcher)  │
                └──────────────┬───────────────────────┘
@@ -51,6 +53,8 @@ The solution file is `LocalWinAI.slnx` at the repository root.
                ┌────────────────────────────────┐
                │           Domain               │
                │  ChatMessageSender             │
+               │  ChatSession / ChatMessage     │
+               │  IChatSessionRepository        │
                │  ILanguageModelService         │
                │  IUsageTracker / UsageEvent    │
                └────────────────────────────────┘
@@ -101,18 +105,25 @@ Timeouts: connect = 5 s, inference/embed = 120 s.
 | Type | Layer | Purpose |
 |---|---|---|
 | `ChatMessageSender` | Domain | Enum: User or AI |
+| `ChatMessage` | Domain | Immutable record of a single message: Sender, Text, Timestamp |
+| `ChatSession` | Domain | Aggregate root: Id, Title, CreatedAt, LastUsedAt, Messages |
+| `IChatSessionRepository` | Domain | Persistence contract for chat sessions |
 | `ILanguageModelService` | Domain | Interface for on-device text generation |
 | `IUsageTracker` | Domain | Write interface: append a `UsageEvent` to the shared log |
 | `UsageEvent` | Domain | Per-call record: source, tool, estimated tokens, duration |
 | `IChatService` | Application | Interface for conversation management |
-| `ChatService` | Application | Manages history, builds prompts, records usage, delegates to model |
+| `ChatService` | Application | Builds prompts from session history, delegates to model, persists after each exchange |
+| `IChatSessionManager` | Application | Orchestrates active session: create, switch, delete, persist, title generation |
+| `ChatSessionManager` | Application | Implements `IChatSessionManager`; fires background title generation after first exchange |
 | `ObservableChatMessage` | Application | UI-bindable message with mutable Text and IsWaiting |
-| `ChatPageViewModel` | Application | MVVM ViewModel for the chat page |
+| `ChatSessionSummaryViewModel` | Application | Observable sidebar item: Id, Title (observable), RelativeDateText |
+| `ChatPageViewModel` | Application | MVVM ViewModel for the chat page including session sidebar |
 | `IUsageAggregateService` | Application | Read interface: aggregated stats + `AggregatesChanged` event |
 | `UsageAggregates` | Application | Computed totals, per-tool breakdown, 7-day activity, cost estimate |
 | `StatisticsPageViewModel` | Application | MVVM ViewModel for the statistics page |
 | `WindowsLanguageModelService` | Infrastructure | Windows Copilot Runtime implementation of `ILanguageModelService` |
-| `NamedPipeInferenceServer` | Infrastructure | `IHostedService` that listens on the `LocalWinAI-Inference` named pipe and delegates to `ILanguageModelService` |
+| `NamedPipeInferenceServer` | Infrastructure | `IHostedService` that listens on the `LocalWinAI-Inference` named pipe |
+| `ChatSessionRepository` | Infrastructure | File-based `IChatSessionRepository`; stores sessions under `%LOCALAPPDATA%\LocalWinAI\sessions\` |
 | `PipeConstants` | Infrastructure | Shared pipe name and timeout constants |
 | `PipeRequest` / `PipeResponse` | Infrastructure | JSON record types for the pipe protocol |
 | `UsageTracker` | Infrastructure | Appends NDJSON events to `%LOCALAPPDATA%\LocalWinAI\usage.ndjson` |
@@ -122,6 +133,18 @@ Timeouts: connect = 5 s, inference/embed = 120 s.
 | `LocalClassifyTool` | Mcp | MCP tool: text classification via prompted inference |
 | `LocalEmbedTool` | Mcp | MCP tool: generate a semantic embedding vector |
 | `PipeLanguageModelService` | McpHost | `ILanguageModelService` implementation that forwards requests over the named pipe |
+
+## Session Persistence Layout
+
+```
+%LocalAppData%\LocalWinAI\sessions\
+  index.json           ← [{Id, Title, LastUsedAt, CreatedAt}, ...]  (sidebar metadata)
+  {guid1}.json         ← Full ChatSession with all messages
+  {guid2}.json
+  ...
+```
+
+`GetAllAsync` reads only `index.json` (fast sidebar load). `GetAsync(id)` reads the full `{id}.json` file. `SaveAsync` updates both the session file and `index.json`.
 
 ## MCP Host Architecture Rationale
 

--- a/Doc/Features.md
+++ b/Doc/Features.md
@@ -2,6 +2,19 @@
 
 ## Finished features available right now
 
+### Persistent Chat Sessions
+- Conversations are saved to disk and survive app restarts.
+- A **session sidebar** (left pane) lists all sessions ordered by most-recently used.
+- Each sidebar item shows the session **title** and a relative date ("Today", "Yesterday", "N days ago").
+- A **+ New Session** button at the top of the sidebar starts a fresh conversation.
+- **Right-click** any session item to reveal a **Delete** option.
+- Switching sessions reloads the full message history for the selected session.
+- After the first AI response in a new session the app automatically generates a 4–6-word title by
+  calling the local model in the background. If the model is unavailable, the first 50 characters
+  of the user's message are used as the fallback title.
+- Sessions are persisted under `%LocalAppData%\LocalWinAI\sessions\` as JSON files, with a lightweight
+  `index.json` used for the sidebar (avoids loading full message history just to render the list).
+
 ### Usage Statistics
 - A dedicated **Statistics** page in the navigation shows how much work the local NPU has done.
 - Tracks every chat turn and every MCP tool call: token estimates, call counts, and duration.
@@ -15,10 +28,9 @@
 
 ### On-device Chat
 - Send text messages to the local Windows Runtime language model.
-- Conversation history is maintained across turns within a session (history is passed as a single joined prompt).
+- Conversation history is maintained within a session and across restarts (persisted to disk).
 - Streaming-style UX: a spinner appears in the AI message bubble while inference runs.
-- **Clear** button resets the conversation and clears all message bubbles.
-- Enter key submits the current input message.
+- Enter key submits the current input message. Ctrl+Enter inserts a newline.
 - Chat log auto-scrolls to the latest message.
 
 ### MCP Server (Claude Code Integration)
@@ -58,4 +70,5 @@ A dedicated **Settings** page in the navigation lets you manage Claude Code inte
 
 - Workspace-aware file reasoning.
 - Markdown rendering in AI message bubbles.
-- Persistent conversation history across app restarts.
+- Session search / filter.
+- Manual session title editing.

--- a/Doc/Project.md
+++ b/Doc/Project.md
@@ -37,6 +37,6 @@ Src/          — All source code and the solution file
 
 ## Requirements
 
-- Windows 11 25H2 or later
+- Windows 11 24H2 (Build 26100) or later with Copilot+ feature enabled
 - Copilot+ PC with NPU (or compatible hardware for local model inference)
 - `systemAIModels` capability declared in the app manifest

--- a/Src/App/ChatPage.xaml
+++ b/Src/App/ChatPage.xaml
@@ -4,72 +4,123 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:local="using:LocalWinAI"
     xmlns:app="using:LocalWinAI.Application"
+    xmlns:sessions="using:LocalWinAI.Application.Sessions"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d">
+
     <Grid>
-        <Grid.RowDefinitions>
-            <RowDefinition Height="Auto"/>
-            <RowDefinition Height="*"/>
-        </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
+            <ColumnDefinition Width="240"/>
             <ColumnDefinition Width="*"/>
-            <ColumnDefinition Width="Auto"/>
-            <ColumnDefinition Width="Auto"/>
         </Grid.ColumnDefinitions>
 
-        <TextBox Grid.Column="0" Grid.Row="0"
-                 Text="{x:Bind ViewModel.InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
-                 PlaceholderText="Type your message here..."
-                 AcceptsReturn="True"
-                 MaxHeight="200"
-                 PreviewKeyDown="InputTextBox_KeyDown" />
-        <Button Grid.Column="1" Grid.Row="0"
-                Command="{x:Bind ViewModel.GenerateResponseCommand}"
-                Content="Ask" />
-        <Button Grid.Column="2" Grid.Row="0"
-                Command="{x:Bind ViewModel.ClearConversationCommand}"
-                Content="Clear" />
+        <!-- Session sidebar -->
+        <Grid Grid.Column="0" BorderBrush="{ThemeResource DividerStrokeColorDefaultBrush}" BorderThickness="0,0,1,0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
 
-        <!-- Spinner overlay -->
-        <Grid Grid.RowSpan="2" Grid.ColumnSpan="3"
-              Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay}">
-            <ProgressRing IsActive="True" Width="64" Height="64" HorizontalAlignment="Center" VerticalAlignment="Center"/>
-        </Grid>
+            <Button Grid.Row="0"
+                    Margin="8"
+                    HorizontalAlignment="Stretch"
+                    Command="{x:Bind ViewModel.NewSessionCommand}"
+                    Content="+ New Session"/>
 
-        <!-- Chat messages -->
-        <ScrollViewer x:Name="ResponseScrollViewer" Grid.Row="1" Grid.ColumnSpan="3" VerticalScrollBarVisibility="Visible">
-            <ItemsControl ItemsSource="{x:Bind ViewModel.ChatMessages, Mode=OneWay}">
-                <ItemsControl.ItemTemplate>
-                    <DataTemplate x:DataType="app:ObservableChatMessage">
-                        <Grid Margin="8">
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="*" />
-                                <ColumnDefinition Width="Auto" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <Grid HorizontalAlignment="{x:Bind Sender, Converter={StaticResource SenderToAlignmentConverter}}"
-                                  Grid.ColumnSpan="2"
-                                  Grid.Column="{x:Bind Sender, Converter={StaticResource SenderToColumnConverter}}">
-                                <Border CornerRadius="12"
-                                        Background="#40ffffff"
-                                        Padding="12,8">
-                                    <Grid>
-                                        <RichTextBlock TextWrapping="Wrap" IsTextSelectionEnabled="True">
-                                            <Paragraph>
-                                                <Run Text="{x:Bind Text, Mode=OneWay}" />
-                                            </Paragraph>
-                                        </RichTextBlock>
-                                        <ProgressRing IsActive="{x:Bind IsWaiting, Mode=OneWay}"
-                                                      Width="24" Height="24" Margin="32,0,0,0"
-                                                      Visibility="{x:Bind IsWaiting, Converter={StaticResource BoolToVisibilityConverter}}"/>
-                                    </Grid>
-                                </Border>
-                            </Grid>
+            <ListView x:Name="SessionListView"
+                      Grid.Row="1"
+                      ItemsSource="{x:Bind ViewModel.Sessions, Mode=OneWay}"
+                      SelectionChanged="SessionListView_SelectionChanged">
+                <ListView.ItemTemplate>
+                    <DataTemplate x:DataType="sessions:ChatSessionSummaryViewModel">
+                        <Grid Padding="4,2">
+                            <Grid.ContextFlyout>
+                                <MenuFlyout>
+                                    <MenuFlyoutItem Text="Delete"
+                                                    Tag="{x:Bind Id}"
+                                                    Click="DeleteSession_Click"/>
+                                </MenuFlyout>
+                            </Grid.ContextFlyout>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"/>
+                                <RowDefinition Height="Auto"/>
+                            </Grid.RowDefinitions>
+                            <TextBlock Grid.Row="0"
+                                       Text="{x:Bind Title, Mode=OneWay}"
+                                       TextTrimming="CharacterEllipsis"
+                                       Style="{ThemeResource BodyStrongTextBlockStyle}"/>
+                            <TextBlock Grid.Row="1"
+                                       Text="{x:Bind RelativeDateText}"
+                                       Style="{ThemeResource CaptionTextBlockStyle}"
+                                       Foreground="{ThemeResource TextFillColorSecondaryBrush}"/>
                         </Grid>
                     </DataTemplate>
-                </ItemsControl.ItemTemplate>
-            </ItemsControl>
-        </ScrollViewer>
+                </ListView.ItemTemplate>
+            </ListView>
+        </Grid>
+
+        <!-- Chat area -->
+        <Grid Grid.Column="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="*"/>
+                <ColumnDefinition Width="Auto"/>
+            </Grid.ColumnDefinitions>
+
+            <TextBox Grid.Column="0" Grid.Row="0"
+                     Text="{x:Bind ViewModel.InputText, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                     PlaceholderText="Type your message here..."
+                     AcceptsReturn="True"
+                     MaxHeight="200"
+                     PreviewKeyDown="InputTextBox_KeyDown"/>
+            <Button Grid.Column="1" Grid.Row="0"
+                    Command="{x:Bind ViewModel.GenerateResponseCommand}"
+                    Content="Ask"/>
+
+            <!-- Spinner overlay -->
+            <Grid Grid.RowSpan="2" Grid.ColumnSpan="2"
+                  Visibility="{x:Bind ViewModel.IsBusy, Mode=OneWay}">
+                <ProgressRing IsActive="True" Width="64" Height="64" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+            </Grid>
+
+            <!-- Chat messages -->
+            <ScrollViewer x:Name="ResponseScrollViewer" Grid.Row="1" Grid.ColumnSpan="2" VerticalScrollBarVisibility="Visible">
+                <ItemsControl ItemsSource="{x:Bind ViewModel.ChatMessages, Mode=OneWay}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="app:ObservableChatMessage">
+                            <Grid Margin="8">
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="*"/>
+                                    <ColumnDefinition Width="Auto"/>
+                                    <ColumnDefinition Width="*"/>
+                                </Grid.ColumnDefinitions>
+                                <Grid HorizontalAlignment="{x:Bind Sender, Converter={StaticResource SenderToAlignmentConverter}}"
+                                      Grid.ColumnSpan="2"
+                                      Grid.Column="{x:Bind Sender, Converter={StaticResource SenderToColumnConverter}}">
+                                    <Border CornerRadius="12"
+                                            Background="#40ffffff"
+                                            Padding="12,8">
+                                        <Grid>
+                                            <RichTextBlock TextWrapping="Wrap" IsTextSelectionEnabled="True">
+                                                <Paragraph>
+                                                    <Run Text="{x:Bind Text, Mode=OneWay}"/>
+                                                </Paragraph>
+                                            </RichTextBlock>
+                                            <ProgressRing IsActive="{x:Bind IsWaiting, Mode=OneWay}"
+                                                          Width="24" Height="24" Margin="32,0,0,0"
+                                                          Visibility="{x:Bind IsWaiting, Converter={StaticResource BoolToVisibilityConverter}}"/>
+                                        </Grid>
+                                    </Border>
+                                </Grid>
+                            </Grid>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+            </ScrollViewer>
+        </Grid>
     </Grid>
 </Page>

--- a/Src/App/ChatPage.xaml.cs
+++ b/Src/App/ChatPage.xaml.cs
@@ -1,6 +1,7 @@
 using System.Collections.Specialized;
 using System.ComponentModel;
 using LocalWinAI.Application;
+using LocalWinAI.Application.Sessions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.UI.Input;
 using Microsoft.UI.Xaml.Controls;
@@ -13,29 +14,30 @@ public sealed partial class ChatPage : Page
 {
     public ChatPageViewModel ViewModel { get; }
     private ObservableChatMessage? _lastMessage;
+    private bool _suppressSelectionChanged;
 
     public ChatPage()
     {
         this.InitializeComponent();
         ViewModel = App.Services.GetRequiredService<ChatPageViewModel>();
         ViewModel.ChatMessages.CollectionChanged += ChatMessages_CollectionChanged;
+        ViewModel.PropertyChanged += ViewModel_PropertyChanged;
         SubscribeToLastMessage();
+        Loaded += async (_, _) => await ViewModel.InitializeAsync();
     }
 
     private async void ChatMessages_CollectionChanged(object? sender, NotifyCollectionChangedEventArgs e)
     {
-        if (ResponseScrollViewer != null)
-        {
-            SubscribeToLastMessage();
-            ResponseScrollViewer.ChangeView(null, double.MaxValue, null);
-            await Task.Delay(500);
-            ResponseScrollViewer.ChangeView(null, double.MaxValue, null);
-        }
+        if (ResponseScrollViewer is null) return;
+        SubscribeToLastMessage();
+        ResponseScrollViewer.ChangeView(null, double.MaxValue, null);
+        await Task.Delay(500);
+        ResponseScrollViewer.ChangeView(null, double.MaxValue, null);
     }
 
     private void SubscribeToLastMessage()
     {
-        if (_lastMessage != null)
+        if (_lastMessage is not null)
             _lastMessage.PropertyChanged -= LastMessage_PropertyChanged;
 
         if (ViewModel.ChatMessages.Count > 0)
@@ -51,7 +53,7 @@ public sealed partial class ChatPage : Page
 
     private async void LastMessage_PropertyChanged(object? sender, PropertyChangedEventArgs e)
     {
-        if (e.PropertyName == nameof(ObservableChatMessage.Text) && ResponseScrollViewer != null)
+        if (e.PropertyName == nameof(ObservableChatMessage.Text) && ResponseScrollViewer is not null)
         {
             await Task.Delay(500);
             ResponseScrollViewer.ChangeView(null, double.MaxValue, null);
@@ -63,16 +65,42 @@ public sealed partial class ChatPage : Page
         var ctrl = (InputKeyboardSource.GetKeyStateForCurrentThread(Windows.System.VirtualKey.Control)
             & CoreVirtualKeyStates.Down) != 0;
 
-        // Ctrl+Enter - allow newline
         if (e.Key == Windows.System.VirtualKey.Enter && ctrl)
-        {
             return;
-        }
 
         if (e.Key == Windows.System.VirtualKey.Enter && ViewModel.GenerateResponseCommand.CanExecute(null))
         {
             ViewModel.GenerateResponseCommand.Execute(null);
             e.Handled = true;
         }
+    }
+
+    private void SessionListView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+    {
+        if (_suppressSelectionChanged) return;
+        if (e.AddedItems.Count > 0 && e.AddedItems[0] is ChatSessionSummaryViewModel vm)
+            ViewModel.SwitchSessionCommand.Execute(vm.Id);
+    }
+
+    private void ViewModel_PropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(ChatPageViewModel.ActiveSessionId)) return;
+
+        _suppressSelectionChanged = true;
+        try
+        {
+            SessionListView.SelectedItem = ViewModel.Sessions
+                .FirstOrDefault(s => s.Id == ViewModel.ActiveSessionId);
+        }
+        finally
+        {
+            _suppressSelectionChanged = false;
+        }
+    }
+
+    private void DeleteSession_Click(object sender, Microsoft.UI.Xaml.RoutedEventArgs e)
+    {
+        if (sender is MenuFlyoutItem item && item.Tag is Guid id)
+            ViewModel.DeleteSessionCommand.Execute(id);
     }
 }

--- a/Src/LocalWinAI.Application/ApplicationServiceExtensions.cs
+++ b/Src/LocalWinAI.Application/ApplicationServiceExtensions.cs
@@ -1,3 +1,4 @@
+using LocalWinAI.Application.Sessions;
 using LocalWinAI.Application.Settings;
 using LocalWinAI.Application.Statistics;
 using Microsoft.Extensions.DependencyInjection;
@@ -8,6 +9,7 @@ public static class ApplicationServiceExtensions
 {
     public static IServiceCollection AddApplicationServices(this IServiceCollection services)
     {
+        services.AddSingleton<IChatSessionManager, ChatSessionManager>();
         services.AddSingleton<IChatService, ChatService>();
         services.AddSingleton<ChatPageViewModel>();
         services.AddSingleton<SettingsPageViewModel>();

--- a/Src/LocalWinAI.Application/ChatPageViewModel.cs
+++ b/Src/LocalWinAI.Application/ChatPageViewModel.cs
@@ -1,13 +1,17 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using LocalWinAI.Application.Sessions;
 using LocalWinAI.Domain;
+using LocalWinAI.Domain.Sessions;
 
 namespace LocalWinAI.Application;
 
 public partial class ChatPageViewModel : ObservableObject
 {
     private readonly IChatService _chatService;
+    private readonly IChatSessionManager _sessionManager;
+    private readonly SynchronizationContext? _syncContext;
 
     [ObservableProperty]
     public partial string InputText { get; set; } = string.Empty;
@@ -15,23 +19,36 @@ public partial class ChatPageViewModel : ObservableObject
     [ObservableProperty]
     public partial bool IsBusy { get; set; } = false;
 
+    [ObservableProperty]
+    public partial Guid ActiveSessionId { get; set; }
+
     public ObservableCollection<ObservableChatMessage> ChatMessages { get; } = [];
+    public ObservableCollection<ChatSessionSummaryViewModel> Sessions { get; } = [];
 
     public AsyncRelayCommand GenerateResponseCommand { get; }
-    public RelayCommand ClearConversationCommand { get; }
+    public AsyncRelayCommand NewSessionCommand { get; }
+    public AsyncRelayCommand<Guid> SwitchSessionCommand { get; }
+    public AsyncRelayCommand<Guid> DeleteSessionCommand { get; }
 
-    public ChatPageViewModel(IChatService chatService)
+    public ChatPageViewModel(IChatService chatService, IChatSessionManager sessionManager)
     {
         _chatService = chatService;
+        _sessionManager = sessionManager;
+        _syncContext = SynchronizationContext.Current;
+
         GenerateResponseCommand = new AsyncRelayCommand(GenerateResponseAsync);
-        ClearConversationCommand = new RelayCommand(ClearConversation);
+        NewSessionCommand = new AsyncRelayCommand(NewSessionAsync);
+        SwitchSessionCommand = new AsyncRelayCommand<Guid>(SwitchSessionAsync);
+        DeleteSessionCommand = new AsyncRelayCommand<Guid>(DeleteSessionAsync);
+
+        _sessionManager.SessionTitleUpdated += OnSessionTitleUpdated;
     }
 
-    private void ClearConversation()
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
     {
-        InputText = string.Empty;
-        ChatMessages.Clear();
-        _chatService.ClearConversation();
+        await _sessionManager.InitializeAsync(cancellationToken);
+        await RefreshSessionsAsync();
+        LoadActiveSessionMessages();
     }
 
     private async Task GenerateResponseAsync()
@@ -63,4 +80,73 @@ public partial class ChatPageViewModel : ObservableObject
             IsBusy = false;
         }
     }
+
+    private async Task NewSessionAsync()
+    {
+        await _sessionManager.CreateSessionAsync();
+        await RefreshSessionsAsync();
+        LoadActiveSessionMessages();
+    }
+
+    private async Task SwitchSessionAsync(Guid id)
+    {
+        if (id == _sessionManager.ActiveSession.Id)
+            return;
+
+        await _sessionManager.SwitchToSessionAsync(id);
+        LoadActiveSessionMessages();
+        ActiveSessionId = _sessionManager.ActiveSession.Id;
+    }
+
+    private async Task DeleteSessionAsync(Guid id)
+    {
+        await _sessionManager.DeleteSessionAsync(id);
+        await RefreshSessionsAsync();
+        LoadActiveSessionMessages();
+    }
+
+    private async Task RefreshSessionsAsync()
+    {
+        var sessions = await _sessionManager.GetSessionsAsync();
+        Sessions.Clear();
+        foreach (var s in sessions.OrderByDescending(s => s.LastUsedAt))
+            Sessions.Add(ToSummary(s));
+        ActiveSessionId = _sessionManager.ActiveSession.Id;
+    }
+
+    private void LoadActiveSessionMessages()
+    {
+        ChatMessages.Clear();
+        foreach (var msg in _sessionManager.ActiveSession.Messages)
+        {
+            ChatMessages.Add(new ObservableChatMessage
+            {
+                Sender = msg.Sender,
+                Text = msg.Text
+            });
+        }
+        ActiveSessionId = _sessionManager.ActiveSession.Id;
+    }
+
+    private void OnSessionTitleUpdated(object? sender, ChatSession session)
+    {
+        if (_syncContext is not null)
+            _syncContext.Post(_ => ApplyTitleUpdate(session), null);
+        else
+            ApplyTitleUpdate(session);
+    }
+
+    private void ApplyTitleUpdate(ChatSession session)
+    {
+        var vm = Sessions.FirstOrDefault(s => s.Id == session.Id);
+        if (vm is not null)
+            vm.Title = session.Title;
+    }
+
+    private static ChatSessionSummaryViewModel ToSummary(ChatSession s) => new()
+    {
+        Id = s.Id,
+        Title = s.Title,
+        LastUsedAt = s.LastUsedAt
+    };
 }

--- a/Src/LocalWinAI.Application/ChatPageViewModel.cs
+++ b/Src/LocalWinAI.Application/ChatPageViewModel.cs
@@ -12,6 +12,9 @@ public partial class ChatPageViewModel : ObservableObject
     private readonly IChatService _chatService;
     private readonly IChatSessionManager _sessionManager;
     private readonly SynchronizationContext? _syncContext;
+    private CancellationTokenSource? _inFlightCts;
+    private Guid? _inFlightSessionId;
+    private readonly Dictionary<Guid, string> _sessionDrafts = [];
 
     [ObservableProperty]
     public partial string InputText { get; set; } = string.Empty;
@@ -57,35 +60,50 @@ public partial class ChatPageViewModel : ObservableObject
         if (string.IsNullOrEmpty(userMessage))
             return;
 
+        var sessionId = _sessionManager.ActiveSession.Id;
+        _sessionDrafts[sessionId] = userMessage;
+        _inFlightSessionId = sessionId;
+
         IsBusy = true;
         InputText = string.Empty;
-        ChatMessages.Add(new ObservableChatMessage { Text = userMessage, Sender = ChatMessageSender.User });
 
+        _inFlightCts?.Cancel();
+        _inFlightCts?.Dispose();
+        _inFlightCts = new CancellationTokenSource();
+
+        ChatMessages.Add(new ObservableChatMessage { Text = userMessage, Sender = ChatMessageSender.User });
         var aiMessage = new ObservableChatMessage { Text = "...", Sender = ChatMessageSender.AI, IsWaiting = true };
         ChatMessages.Add(aiMessage);
 
         try
         {
-            var response = await _chatService.SendMessageAsync(userMessage);
+            var response = await _chatService.SendMessageAsync(userMessage, _inFlightCts.Token);
             aiMessage.Text = response;
             aiMessage.IsWaiting = false;
+            _sessionDrafts.Remove(sessionId);
         }
+        catch (OperationCanceledException) { }
         catch (Exception e)
         {
             aiMessage.Text = $"Error: {e.Message}";
             aiMessage.IsWaiting = false;
+            _sessionDrafts.Remove(sessionId);
         }
         finally
         {
+            _inFlightSessionId = null;
             IsBusy = false;
         }
     }
 
     private async Task NewSessionAsync()
     {
+        _inFlightCts?.Cancel();
+        IsBusy = false;
         await _sessionManager.CreateSessionAsync();
         await RefreshSessionsAsync();
         LoadActiveSessionMessages();
+        InputText = string.Empty;
     }
 
     private async Task SwitchSessionAsync(Guid id)
@@ -93,16 +111,46 @@ public partial class ChatPageViewModel : ObservableObject
         if (id == _sessionManager.ActiveSession.Id)
             return;
 
+        _inFlightCts?.Cancel();
+
         await _sessionManager.SwitchToSessionAsync(id);
         LoadActiveSessionMessages();
         ActiveSessionId = _sessionManager.ActiveSession.Id;
+
+        IsBusy = _inFlightSessionId == id;
+
+        if (_sessionDrafts.TryGetValue(id, out var draft))
+        {
+            InputText = draft;
+            _sessionDrafts.Remove(id);
+        }
+        else
+        {
+            InputText = string.Empty;
+        }
     }
 
     private async Task DeleteSessionAsync(Guid id)
     {
+        if (id == _sessionManager.ActiveSession.Id)
+            _inFlightCts?.Cancel();
+
         await _sessionManager.DeleteSessionAsync(id);
         await RefreshSessionsAsync();
         LoadActiveSessionMessages();
+
+        var newId = _sessionManager.ActiveSession.Id;
+        IsBusy = _inFlightSessionId == newId;
+
+        if (_sessionDrafts.TryGetValue(newId, out var draft))
+        {
+            InputText = draft;
+            _sessionDrafts.Remove(newId);
+        }
+        else
+        {
+            InputText = string.Empty;
+        }
     }
 
     private async Task RefreshSessionsAsync()

--- a/Src/LocalWinAI.Application/ChatService.cs
+++ b/Src/LocalWinAI.Application/ChatService.cs
@@ -1,36 +1,43 @@
 using System.Diagnostics;
+using LocalWinAI.Application.Sessions;
 using LocalWinAI.Domain;
+using LocalWinAI.Domain.Sessions;
 using LocalWinAI.Domain.Usage;
 
 namespace LocalWinAI.Application;
 
-/// <summary>Orchestrates chat sessions: builds prompts from history and delegates generation to the language model.</summary>
+/// <summary>Orchestrates chat turns: builds prompts from session history and delegates generation to the language model.</summary>
 public sealed class ChatService : IChatService
 {
     private readonly ILanguageModelService _languageModel;
     private readonly IUsageTracker _usageTracker;
-    private readonly List<string> _history = [];
+    private readonly IChatSessionManager _sessionManager;
 
-    public ChatService(ILanguageModelService languageModel, IUsageTracker usageTracker)
+    public ChatService(ILanguageModelService languageModel, IUsageTracker usageTracker, IChatSessionManager sessionManager)
     {
         _languageModel = languageModel;
         _usageTracker = usageTracker;
+        _sessionManager = sessionManager;
     }
 
     public async Task<string> SendMessageAsync(string userMessage, CancellationToken cancellationToken = default)
     {
-        _history.Add(userMessage);
+        var session = _sessionManager.ActiveSession;
+        session.Messages.Add(new ChatMessage(ChatMessageSender.User, userMessage, DateTimeOffset.UtcNow));
 
         var ready = await _languageModel.EnsureReadyAsync(cancellationToken);
         if (!ready)
+        {
+            session.Messages.RemoveAt(session.Messages.Count - 1);
             throw new InvalidOperationException("Language model is not ready.");
+        }
 
-        var prompt = string.Join("\n", _history);
+        var prompt = string.Join("\n", session.Messages.Select(m => m.Text));
         var sw = Stopwatch.StartNew();
         var response = await _languageModel.GenerateResponseAsync(prompt, cancellationToken);
         sw.Stop();
 
-        _history.Add(response);
+        session.Messages.Add(new ChatMessage(ChatMessageSender.AI, response, DateTimeOffset.UtcNow));
 
         await _usageTracker.RecordAsync(new UsageEvent(
             DateTimeOffset.UtcNow,
@@ -40,8 +47,8 @@ public sealed class ChatService : IChatService
             UsageEvent.EstimateTokens(response),
             (int)sw.ElapsedMilliseconds));
 
+        await _sessionManager.PersistActiveSessionAsync();
+
         return response;
     }
-
-    public void ClearConversation() => _history.Clear();
 }

--- a/Src/LocalWinAI.Application/ChatService.cs
+++ b/Src/LocalWinAI.Application/ChatService.cs
@@ -23,7 +23,7 @@ public sealed class ChatService : IChatService
     public async Task<string> SendMessageAsync(string userMessage, CancellationToken cancellationToken = default)
     {
         var session = _sessionManager.ActiveSession;
-        session.Messages.Add(new ChatMessage(ChatMessageSender.User, userMessage, DateTimeOffset.UtcNow));
+        session.AddMessage(new ChatMessage(ChatMessageSender.User, userMessage, DateTimeOffset.UtcNow));
 
         string response;
         try
@@ -31,7 +31,7 @@ public sealed class ChatService : IChatService
             var ready = await _languageModel.EnsureReadyAsync(cancellationToken);
             if (!ready)
             {
-                session.Messages.RemoveAt(session.Messages.Count - 1);
+                session.RemoveLastMessage();
                 throw new InvalidOperationException("Language model is not ready.");
             }
 
@@ -40,7 +40,7 @@ public sealed class ChatService : IChatService
             response = await _languageModel.GenerateResponseAsync(prompt, cancellationToken);
             sw.Stop();
 
-            session.Messages.Add(new ChatMessage(ChatMessageSender.AI, response, DateTimeOffset.UtcNow));
+            session.AddMessage(new ChatMessage(ChatMessageSender.AI, response, DateTimeOffset.UtcNow));
 
             await _usageTracker.RecordAsync(new UsageEvent(
                 DateTimeOffset.UtcNow,
@@ -54,7 +54,7 @@ public sealed class ChatService : IChatService
         }
         catch (OperationCanceledException)
         {
-            session.Messages.RemoveAt(session.Messages.Count - 1);
+            session.RemoveLastMessage();
             throw;
         }
 

--- a/Src/LocalWinAI.Application/ChatService.cs
+++ b/Src/LocalWinAI.Application/ChatService.cs
@@ -25,29 +25,38 @@ public sealed class ChatService : IChatService
         var session = _sessionManager.ActiveSession;
         session.Messages.Add(new ChatMessage(ChatMessageSender.User, userMessage, DateTimeOffset.UtcNow));
 
-        var ready = await _languageModel.EnsureReadyAsync(cancellationToken);
-        if (!ready)
+        string response;
+        try
+        {
+            var ready = await _languageModel.EnsureReadyAsync(cancellationToken);
+            if (!ready)
+            {
+                session.Messages.RemoveAt(session.Messages.Count - 1);
+                throw new InvalidOperationException("Language model is not ready.");
+            }
+
+            var prompt = string.Join("\n", session.Messages.Select(m => m.Text));
+            var sw = Stopwatch.StartNew();
+            response = await _languageModel.GenerateResponseAsync(prompt, cancellationToken);
+            sw.Stop();
+
+            session.Messages.Add(new ChatMessage(ChatMessageSender.AI, response, DateTimeOffset.UtcNow));
+
+            await _usageTracker.RecordAsync(new UsageEvent(
+                DateTimeOffset.UtcNow,
+                "chat",
+                "chat",
+                UsageEvent.EstimateTokens(prompt),
+                UsageEvent.EstimateTokens(response),
+                (int)sw.ElapsedMilliseconds));
+
+            await _sessionManager.PersistActiveSessionAsync();
+        }
+        catch (OperationCanceledException)
         {
             session.Messages.RemoveAt(session.Messages.Count - 1);
-            throw new InvalidOperationException("Language model is not ready.");
+            throw;
         }
-
-        var prompt = string.Join("\n", session.Messages.Select(m => m.Text));
-        var sw = Stopwatch.StartNew();
-        var response = await _languageModel.GenerateResponseAsync(prompt, cancellationToken);
-        sw.Stop();
-
-        session.Messages.Add(new ChatMessage(ChatMessageSender.AI, response, DateTimeOffset.UtcNow));
-
-        await _usageTracker.RecordAsync(new UsageEvent(
-            DateTimeOffset.UtcNow,
-            "chat",
-            "chat",
-            UsageEvent.EstimateTokens(prompt),
-            UsageEvent.EstimateTokens(response),
-            (int)sw.ElapsedMilliseconds));
-
-        await _sessionManager.PersistActiveSessionAsync();
 
         return response;
     }

--- a/Src/LocalWinAI.Application/IChatService.cs
+++ b/Src/LocalWinAI.Application/IChatService.cs
@@ -5,7 +5,4 @@ public interface IChatService
 {
     /// <summary>Sends a user message and returns the AI-generated response.</summary>
     Task<string> SendMessageAsync(string userMessage, CancellationToken cancellationToken = default);
-
-    /// <summary>Clears all conversation history.</summary>
-    void ClearConversation();
 }

--- a/Src/LocalWinAI.Application/Sessions/ChatSessionManager.cs
+++ b/Src/LocalWinAI.Application/Sessions/ChatSessionManager.cs
@@ -8,6 +8,7 @@ public sealed class ChatSessionManager : IChatSessionManager
 {
     private readonly IChatSessionRepository _repository;
     private readonly ILanguageModelService _languageModel;
+    // Assigned in InitializeAsync before any caller can reach ActiveSession.
     private ChatSession _activeSession = null!;
 
     public ChatSession ActiveSession => _activeSession;
@@ -103,7 +104,7 @@ public sealed class ChatSessionManager : IChatSessionManager
 
             session.Title = title;
         }
-        catch
+        catch (Exception)
         {
             session.Title = TruncateTitle(firstUserMessage);
         }

--- a/Src/LocalWinAI.Application/Sessions/ChatSessionManager.cs
+++ b/Src/LocalWinAI.Application/Sessions/ChatSessionManager.cs
@@ -1,0 +1,124 @@
+using LocalWinAI.Domain;
+using LocalWinAI.Domain.Sessions;
+
+namespace LocalWinAI.Application.Sessions;
+
+/// <summary>Implements <see cref="IChatSessionManager"/>, wrapping the repository and tracking the active session.</summary>
+public sealed class ChatSessionManager : IChatSessionManager
+{
+    private readonly IChatSessionRepository _repository;
+    private readonly ILanguageModelService _languageModel;
+    private ChatSession _activeSession = null!;
+
+    public ChatSession ActiveSession => _activeSession;
+    public event EventHandler<ChatSession>? SessionTitleUpdated;
+
+    public ChatSessionManager(IChatSessionRepository repository, ILanguageModelService languageModel)
+    {
+        _repository = repository;
+        _languageModel = languageModel;
+    }
+
+    public async Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        var all = await _repository.GetAllAsync();
+        if (all.Count > 0)
+        {
+            var mostRecent = all.OrderByDescending(s => s.LastUsedAt).First();
+            _activeSession = await _repository.GetAsync(mostRecent.Id) ?? new ChatSession();
+        }
+        else
+        {
+            _activeSession = await CreateNewAndSaveAsync();
+        }
+    }
+
+    public Task<IReadOnlyList<ChatSession>> GetSessionsAsync() => _repository.GetAllAsync();
+
+    public async Task<ChatSession> CreateSessionAsync()
+    {
+        _activeSession = await CreateNewAndSaveAsync();
+        return _activeSession;
+    }
+
+    public async Task SwitchToSessionAsync(Guid id)
+    {
+        var session = await _repository.GetAsync(id)
+            ?? throw new InvalidOperationException($"Session {id} not found.");
+        _activeSession = session;
+        _activeSession.LastUsedAt = DateTimeOffset.UtcNow;
+        await _repository.SaveAsync(_activeSession);
+    }
+
+    public async Task DeleteSessionAsync(Guid id)
+    {
+        await _repository.DeleteAsync(id);
+
+        if (_activeSession.Id == id)
+        {
+            var remaining = await _repository.GetAllAsync();
+            if (remaining.Count > 0)
+            {
+                var next = remaining.OrderByDescending(s => s.LastUsedAt).First();
+                _activeSession = await _repository.GetAsync(next.Id) ?? new ChatSession();
+            }
+            else
+            {
+                _activeSession = await CreateNewAndSaveAsync();
+            }
+        }
+    }
+
+    public async Task PersistActiveSessionAsync()
+    {
+        _activeSession.LastUsedAt = DateTimeOffset.UtcNow;
+        await _repository.SaveAsync(_activeSession);
+
+        // After first exchange (one user + one AI message), generate a title in the background.
+        if (_activeSession.Messages.Count == 2 && _activeSession.Title == "New conversation")
+        {
+            var firstUserMessage = _activeSession.Messages[0].Text;
+            _ = GenerateTitleAsync(_activeSession, firstUserMessage);
+        }
+    }
+
+    private async Task GenerateTitleAsync(ChatSession session, string firstUserMessage)
+    {
+        try
+        {
+            var ready = await _languageModel.EnsureReadyAsync();
+            string title;
+            if (ready)
+            {
+                var prompt = $"Summarize the following user message as a conversation title in 4 to 6 words: {firstUserMessage}";
+                var raw = await _languageModel.GenerateResponseAsync(prompt);
+                title = raw.Trim().TrimEnd('.');
+                if (string.IsNullOrWhiteSpace(title))
+                    title = TruncateTitle(firstUserMessage);
+            }
+            else
+            {
+                title = TruncateTitle(firstUserMessage);
+            }
+
+            session.Title = title;
+        }
+        catch
+        {
+            session.Title = TruncateTitle(firstUserMessage);
+        }
+
+        await _repository.SaveAsync(session);
+        SessionTitleUpdated?.Invoke(this, session);
+    }
+
+    private async Task<ChatSession> CreateNewAndSaveAsync()
+    {
+        var session = new ChatSession();
+        await _repository.SaveAsync(session);
+        return session;
+    }
+
+    private static string TruncateTitle(string message)
+        => message.Length <= 50 ? message : message[..50];
+}

--- a/Src/LocalWinAI.Application/Sessions/ChatSessionSummaryViewModel.cs
+++ b/Src/LocalWinAI.Application/Sessions/ChatSessionSummaryViewModel.cs
@@ -1,0 +1,29 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+
+namespace LocalWinAI.Application.Sessions;
+
+/// <summary>Observable list-item model for the session sidebar.</summary>
+public partial class ChatSessionSummaryViewModel : ObservableObject
+{
+    public Guid Id { get; init; }
+
+    [ObservableProperty]
+    public partial string Title { get; set; } = string.Empty;
+
+    public DateTimeOffset LastUsedAt { get; init; }
+
+    public string RelativeDateText
+    {
+        get
+        {
+            var today = DateTime.UtcNow.Date;
+            var lastUsed = LastUsedAt.UtcDateTime.Date;
+            return (today - lastUsed).Days switch
+            {
+                0 => "Today",
+                1 => "Yesterday",
+                var d => $"{d} days ago"
+            };
+        }
+    }
+}

--- a/Src/LocalWinAI.Application/Sessions/IChatSessionManager.cs
+++ b/Src/LocalWinAI.Application/Sessions/IChatSessionManager.cs
@@ -1,0 +1,31 @@
+using LocalWinAI.Domain.Sessions;
+
+namespace LocalWinAI.Application.Sessions;
+
+/// <summary>Orchestrates which chat session is active and handles lifecycle operations.</summary>
+public interface IChatSessionManager
+{
+    /// <summary>The currently active session. Valid after <see cref="InitializeAsync"/> completes.</summary>
+    ChatSession ActiveSession { get; }
+
+    /// <summary>Raised on a background thread when a session title is updated after auto-generation.</summary>
+    event EventHandler<ChatSession>? SessionTitleUpdated;
+
+    /// <summary>Loads the most-recent session or creates a new one. Must be called once on startup.</summary>
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>Returns lightweight metadata for all sessions, most-recent first.</summary>
+    Task<IReadOnlyList<ChatSession>> GetSessionsAsync();
+
+    /// <summary>Creates a new empty session, making it the active session.</summary>
+    Task<ChatSession> CreateSessionAsync();
+
+    /// <summary>Loads a session by id and makes it the active session.</summary>
+    Task SwitchToSessionAsync(Guid id);
+
+    /// <summary>Deletes a session. Switches to the next available session (or a new one).</summary>
+    Task DeleteSessionAsync(Guid id);
+
+    /// <summary>Persists the active session and, on the first exchange, triggers background title generation.</summary>
+    Task PersistActiveSessionAsync();
+}

--- a/Src/LocalWinAI.Domain/Sessions/ChatMessage.cs
+++ b/Src/LocalWinAI.Domain/Sessions/ChatMessage.cs
@@ -1,0 +1,4 @@
+namespace LocalWinAI.Domain.Sessions;
+
+/// <summary>An immutable record of a single message in a persistent chat session.</summary>
+public sealed record ChatMessage(ChatMessageSender Sender, string Text, DateTimeOffset Timestamp);

--- a/Src/LocalWinAI.Domain/Sessions/ChatSession.cs
+++ b/Src/LocalWinAI.Domain/Sessions/ChatSession.cs
@@ -7,5 +7,10 @@ public sealed class ChatSession
     public string Title { get; set; } = "New conversation";
     public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
     public DateTimeOffset LastUsedAt { get; set; } = DateTimeOffset.UtcNow;
-    public List<ChatMessage> Messages { get; init; } = [];
+
+    private readonly List<ChatMessage> _messages = [];
+    public IReadOnlyList<ChatMessage> Messages => _messages;
+
+    public void AddMessage(ChatMessage message) => _messages.Add(message);
+    public void RemoveLastMessage() => _messages.RemoveAt(_messages.Count - 1);
 }

--- a/Src/LocalWinAI.Domain/Sessions/ChatSession.cs
+++ b/Src/LocalWinAI.Domain/Sessions/ChatSession.cs
@@ -1,0 +1,11 @@
+namespace LocalWinAI.Domain.Sessions;
+
+/// <summary>Aggregate root for a persistent chat session and its message history.</summary>
+public sealed class ChatSession
+{
+    public Guid Id { get; init; } = Guid.NewGuid();
+    public string Title { get; set; } = "New conversation";
+    public DateTimeOffset CreatedAt { get; init; } = DateTimeOffset.UtcNow;
+    public DateTimeOffset LastUsedAt { get; set; } = DateTimeOffset.UtcNow;
+    public List<ChatMessage> Messages { get; init; } = [];
+}

--- a/Src/LocalWinAI.Domain/Sessions/IChatSessionRepository.cs
+++ b/Src/LocalWinAI.Domain/Sessions/IChatSessionRepository.cs
@@ -1,0 +1,17 @@
+namespace LocalWinAI.Domain.Sessions;
+
+/// <summary>Persistence contract for chat sessions.</summary>
+public interface IChatSessionRepository
+{
+    /// <summary>Returns lightweight session metadata for all sessions (no messages), ordered by most-recent first.</summary>
+    Task<IReadOnlyList<ChatSession>> GetAllAsync();
+
+    /// <summary>Returns the full session including all messages, or null if not found.</summary>
+    Task<ChatSession?> GetAsync(Guid id);
+
+    /// <summary>Saves (creates or updates) a session and refreshes the index.</summary>
+    Task SaveAsync(ChatSession session);
+
+    /// <summary>Deletes a session and removes it from the index.</summary>
+    Task DeleteAsync(Guid id);
+}

--- a/Src/LocalWinAI.Infrastructure/InfrastructureServiceExtensions.cs
+++ b/Src/LocalWinAI.Infrastructure/InfrastructureServiceExtensions.cs
@@ -1,8 +1,10 @@
 using LocalWinAI.Application.Settings;
 using LocalWinAI.Application.Statistics;
 using LocalWinAI.Domain;
+using LocalWinAI.Domain.Sessions;
 using LocalWinAI.Domain.Usage;
 using LocalWinAI.Infrastructure.Pipe;
+using LocalWinAI.Infrastructure.Sessions;
 using LocalWinAI.Infrastructure.Settings;
 using LocalWinAI.Infrastructure.Usage;
 using Microsoft.Extensions.DependencyInjection;
@@ -43,12 +45,23 @@ public static class InfrastructureServiceExtensions
         return services;
     }
 
+    /// <summary>
+    /// Registers the file-based chat session repository.
+    /// Call this only from the UI app.
+    /// </summary>
+    public static IServiceCollection AddSessionRepository(this IServiceCollection services)
+    {
+        services.AddSingleton<IChatSessionRepository, ChatSessionRepository>();
+        return services;
+    }
+
     /// <summary>Convenience method that registers all infrastructure services for the UI app.</summary>
     public static IServiceCollection AddInfrastructureServices(this IServiceCollection services)
     {
         services.AddCoreInfrastructureServices();
         services.AddWindowsAiServices();
         services.AddPipeInferenceServer();
+        services.AddSessionRepository();
         return services;
     }
 }

--- a/Src/LocalWinAI.Infrastructure/Sessions/ChatSessionRepository.cs
+++ b/Src/LocalWinAI.Infrastructure/Sessions/ChatSessionRepository.cs
@@ -52,14 +52,29 @@ public sealed class ChatSessionRepository : IChatSessionRepository
             return null;
 
         var json = await File.ReadAllTextAsync(path);
-        return JsonSerializer.Deserialize<ChatSession>(json, JsonOptions);
+        var doc = JsonSerializer.Deserialize<ChatSessionDocument>(json, JsonOptions);
+        if (doc is null)
+            return null;
+
+        var session = new ChatSession { Id = doc.Id, Title = doc.Title, CreatedAt = doc.CreatedAt, LastUsedAt = doc.LastUsedAt };
+        foreach (var m in doc.Messages)
+            session.AddMessage(m);
+        return session;
     }
 
     public async Task SaveAsync(ChatSession session)
     {
         Directory.CreateDirectory(StorageRoot);
 
-        var sessionJson = JsonSerializer.Serialize(session, JsonOptions);
+        var doc = new ChatSessionDocument
+        {
+            Id = session.Id,
+            Title = session.Title,
+            CreatedAt = session.CreatedAt,
+            LastUsedAt = session.LastUsedAt,
+            Messages = session.Messages.ToList()
+        };
+        var sessionJson = JsonSerializer.Serialize(doc, JsonOptions);
         await WriteWithRetryAsync(SessionPath(session.Id), sessionJson);
         await UpdateIndexAsync(session);
     }
@@ -118,7 +133,6 @@ public sealed class ChatSessionRepository : IChatSessionRepository
             {
                 await Task.Delay(50);
             }
-            catch (IOException) { }
         }
     }
 
@@ -126,4 +140,13 @@ public sealed class ChatSessionRepository : IChatSessionRepository
     private static string IndexPath() => Path.Combine(StorageRoot, "index.json");
 
     private sealed record SessionIndexEntry(Guid Id, string Title, DateTimeOffset CreatedAt, DateTimeOffset LastUsedAt);
+
+    private sealed class ChatSessionDocument
+    {
+        public Guid Id { get; set; }
+        public string Title { get; set; } = string.Empty;
+        public DateTimeOffset CreatedAt { get; set; }
+        public DateTimeOffset LastUsedAt { get; set; }
+        public List<ChatMessage> Messages { get; set; } = [];
+    }
 }

--- a/Src/LocalWinAI.Infrastructure/Sessions/ChatSessionRepository.cs
+++ b/Src/LocalWinAI.Infrastructure/Sessions/ChatSessionRepository.cs
@@ -1,0 +1,129 @@
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using LocalWinAI.Domain.Sessions;
+
+namespace LocalWinAI.Infrastructure.Sessions;
+
+/// <summary>
+/// Persists chat sessions under <c>%LocalAppData%\LocalWinAI\sessions\</c>.
+/// Each session is stored as <c>{id}.json</c>. A lightweight <c>index.json</c> holds
+/// <c>{ Id, Title, LastUsedAt, CreatedAt }</c> so the sidebar can be populated without
+/// loading every full session file.
+/// </summary>
+public sealed class ChatSessionRepository : IChatSessionRepository
+{
+    internal static readonly string StorageRoot = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
+        "LocalWinAI",
+        "sessions");
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = true,
+        Converters = { new JsonStringEnumConverter() }
+    };
+
+    public async Task<IReadOnlyList<ChatSession>> GetAllAsync()
+    {
+        var indexPath = IndexPath();
+        if (!File.Exists(indexPath))
+            return [];
+
+        var json = await File.ReadAllTextAsync(indexPath);
+        var index = JsonSerializer.Deserialize<List<SessionIndexEntry>>(json, JsonOptions) ?? [];
+
+        return index
+            .Select(e => new ChatSession
+            {
+                Id = e.Id,
+                Title = e.Title,
+                CreatedAt = e.CreatedAt,
+                LastUsedAt = e.LastUsedAt
+            })
+            .ToList();
+    }
+
+    public async Task<ChatSession?> GetAsync(Guid id)
+    {
+        var path = SessionPath(id);
+        if (!File.Exists(path))
+            return null;
+
+        var json = await File.ReadAllTextAsync(path);
+        return JsonSerializer.Deserialize<ChatSession>(json, JsonOptions);
+    }
+
+    public async Task SaveAsync(ChatSession session)
+    {
+        Directory.CreateDirectory(StorageRoot);
+
+        var sessionJson = JsonSerializer.Serialize(session, JsonOptions);
+        await WriteWithRetryAsync(SessionPath(session.Id), sessionJson);
+        await UpdateIndexAsync(session);
+    }
+
+    public async Task DeleteAsync(Guid id)
+    {
+        var path = SessionPath(id);
+        if (File.Exists(path))
+            File.Delete(path);
+
+        var indexPath = IndexPath();
+        if (!File.Exists(indexPath))
+            return;
+
+        var json = await File.ReadAllTextAsync(indexPath);
+        var index = JsonSerializer.Deserialize<List<SessionIndexEntry>>(json, JsonOptions) ?? [];
+        index.RemoveAll(e => e.Id == id);
+        await WriteWithRetryAsync(indexPath, JsonSerializer.Serialize(index, JsonOptions));
+    }
+
+    private async Task UpdateIndexAsync(ChatSession session)
+    {
+        var indexPath = IndexPath();
+        List<SessionIndexEntry> index = [];
+
+        if (File.Exists(indexPath))
+        {
+            var existing = await File.ReadAllTextAsync(indexPath);
+            index = JsonSerializer.Deserialize<List<SessionIndexEntry>>(existing, JsonOptions) ?? [];
+        }
+
+        var i = index.FindIndex(e => e.Id == session.Id);
+        var entry = new SessionIndexEntry(session.Id, session.Title, session.CreatedAt, session.LastUsedAt);
+        if (i >= 0)
+            index[i] = entry;
+        else
+            index.Add(entry);
+
+        await WriteWithRetryAsync(indexPath, JsonSerializer.Serialize(index, JsonOptions));
+    }
+
+    private static async Task WriteWithRetryAsync(string path, string content)
+    {
+        var bytes = Encoding.UTF8.GetBytes(content);
+        for (int attempt = 0; attempt < 3; attempt++)
+        {
+            try
+            {
+                await using var stream = new FileStream(
+                    path, FileMode.Create, FileAccess.Write,
+                    FileShare.None, bufferSize: 4096, useAsync: true);
+                await stream.WriteAsync(bytes);
+                return;
+            }
+            catch (IOException) when (attempt < 2)
+            {
+                await Task.Delay(50);
+            }
+            catch (IOException) { }
+        }
+    }
+
+    private static string SessionPath(Guid id) => Path.Combine(StorageRoot, $"{id}.json");
+    private static string IndexPath() => Path.Combine(StorageRoot, "index.json");
+
+    private sealed record SessionIndexEntry(Guid Id, string Title, DateTimeOffset CreatedAt, DateTimeOffset LastUsedAt);
+}

--- a/Src/LocalWinAI.Infrastructure/WindowsLanguageModelService.cs
+++ b/Src/LocalWinAI.Infrastructure/WindowsLanguageModelService.cs
@@ -17,14 +17,14 @@ public sealed class WindowsLanguageModelService : ILanguageModelService, IDispos
             if (readyState == AIFeatureReadyState.Ready)
                 return true;
 
-            var op = await LanguageModel.EnsureReadyAsync();
+            var op = await LanguageModel.EnsureReadyAsync().AsTask(cancellationToken);
             if (op.Status == AIFeatureReadyResultState.Success)
                 return true;
 
             throw new InvalidOperationException(
                 $"Language model not ready. GetReadyState={readyState}, EnsureReadyAsync={op.Status}");
         }
-        catch (Exception ex) when (ex is not InvalidOperationException)
+        catch (Exception ex) when (ex is not InvalidOperationException and not OperationCanceledException)
         {
             throw new InvalidOperationException(
                 $"Language model initialization failed: {ex.GetType().Name} 0x{ex.HResult:X8}: {ex.Message}", ex);
@@ -33,8 +33,8 @@ public sealed class WindowsLanguageModelService : ILanguageModelService, IDispos
 
     public async Task<string> GenerateResponseAsync(string prompt, CancellationToken cancellationToken = default)
     {
-        _languageModel ??= await LanguageModel.CreateAsync();
-        var result = await _languageModel.GenerateResponseAsync(prompt);
+        _languageModel ??= await LanguageModel.CreateAsync().AsTask(cancellationToken);
+        var result = await _languageModel.GenerateResponseAsync(prompt).AsTask(cancellationToken);
         return result.Text;
     }
 

--- a/Src/LocalWinAI.Tests/ChatPageViewModelTests.cs
+++ b/Src/LocalWinAI.Tests/ChatPageViewModelTests.cs
@@ -94,7 +94,7 @@ public class ChatPageViewModelTests
     public async Task InitializeAsync_LoadsSessionsAndMessages()
     {
         var (vm, _, sessionManager) = CreateVm();
-        sessionManager.ActiveSession.Messages.Add(
+        sessionManager.ActiveSession.AddMessage(
             new LocalWinAI.Domain.Sessions.ChatMessage(ChatMessageSender.User, "Hi", DateTimeOffset.UtcNow));
 
         await vm.InitializeAsync();
@@ -125,7 +125,7 @@ public class ChatPageViewModelTests
 
         // Add a second session directly so active session stays as session 1.
         var other = new LocalWinAI.Domain.Sessions.ChatSession();
-        other.Messages.Add(new LocalWinAI.Domain.Sessions.ChatMessage(ChatMessageSender.User, "Other session", DateTimeOffset.UtcNow));
+        other.AddMessage(new LocalWinAI.Domain.Sessions.ChatMessage(ChatMessageSender.User, "Other session", DateTimeOffset.UtcNow));
         sessionManager.AllSessions.Add(other);
 
         await vm.SwitchSessionCommand.ExecuteAsync(other.Id);

--- a/Src/LocalWinAI.Tests/ChatPageViewModelTests.cs
+++ b/Src/LocalWinAI.Tests/ChatPageViewModelTests.cs
@@ -7,11 +7,29 @@ namespace LocalWinAI.Tests;
 
 public class ChatPageViewModelTests
 {
+    private static (ChatPageViewModel vm, FakeChatService chatService, FakeChatSessionManager sessionManager) CreateVm()
+    {
+        // Clear the xUnit SynchronizationContext so the ViewModel dispatches title updates
+        // synchronously during tests (the real app captures the WinUI dispatcher context).
+        var prev = SynchronizationContext.Current;
+        SynchronizationContext.SetSynchronizationContext(null);
+        try
+        {
+            var chatService = new FakeChatService();
+            var sessionManager = new FakeChatSessionManager();
+            return (new ChatPageViewModel(chatService, sessionManager), chatService, sessionManager);
+        }
+        finally
+        {
+            SynchronizationContext.SetSynchronizationContext(prev);
+        }
+    }
+
     [Fact]
     public async Task GenerateResponseCommand_AddsUserMessageThenAiResponse()
     {
-        var chatService = new FakeChatService { Response = "AI says hi" };
-        var vm = new ChatPageViewModel(chatService);
+        var (vm, chatService, _) = CreateVm();
+        chatService.Response = "AI says hi";
         vm.InputText = "Hello";
 
         await vm.GenerateResponseCommand.ExecuteAsync(null);
@@ -27,8 +45,7 @@ public class ChatPageViewModelTests
     [Fact]
     public async Task GenerateResponseCommand_ClearsInputText()
     {
-        var chatService = new FakeChatService();
-        var vm = new ChatPageViewModel(chatService);
+        var (vm, _, _) = CreateVm();
         vm.InputText = "Hello";
 
         await vm.GenerateResponseCommand.ExecuteAsync(null);
@@ -39,8 +56,8 @@ public class ChatPageViewModelTests
     [Fact]
     public async Task GenerateResponseCommand_WhenModelFails_ShowsErrorInAiMessage()
     {
-        var chatService = new FakeChatService { ThrowOnSend = true };
-        var vm = new ChatPageViewModel(chatService);
+        var (vm, chatService, _) = CreateVm();
+        chatService.ThrowOnSend = true;
         vm.InputText = "Hello";
 
         await vm.GenerateResponseCommand.ExecuteAsync(null);
@@ -53,8 +70,7 @@ public class ChatPageViewModelTests
     [Fact]
     public async Task GenerateResponseCommand_WithEmptyInput_DoesNothing()
     {
-        var chatService = new FakeChatService();
-        var vm = new ChatPageViewModel(chatService);
+        var (vm, chatService, _) = CreateVm();
         vm.InputText = "   ";
 
         await vm.GenerateResponseCommand.ExecuteAsync(null);
@@ -64,31 +80,87 @@ public class ChatPageViewModelTests
     }
 
     [Fact]
-    public void ClearConversationCommand_ClearsMessagesAndInput()
+    public async Task GenerateResponseCommand_IsBusyResetAfterCompletion()
     {
-        var chatService = new FakeChatService();
-        var vm = new ChatPageViewModel(chatService);
-        vm.ChatMessages.Add(new ObservableChatMessage { Sender = ChatMessageSender.User, Text = "Hi" });
-        vm.InputText = "typing...";
-
-        vm.ClearConversationCommand.Execute(null);
-
-        vm.ChatMessages.Should().BeEmpty();
-        vm.InputText.Should().BeEmpty();
-        chatService.ConversationCleared.Should().BeTrue();
-    }
-
-    [Fact]
-    public async Task GenerateResponseCommand_IsBusyDuringExecution()
-    {
-        var tcs = new TaskCompletionSource<string>();
-        var chatService = new FakeChatService();
-        var vm = new ChatPageViewModel(chatService);
+        var (vm, _, _) = CreateVm();
         vm.InputText = "Hello";
 
-        // IsBusy resets after completion since we use FakeChatService (synchronous)
         await vm.GenerateResponseCommand.ExecuteAsync(null);
 
         vm.IsBusy.Should().BeFalse();
+    }
+
+    [Fact]
+    public async Task InitializeAsync_LoadsSessionsAndMessages()
+    {
+        var (vm, _, sessionManager) = CreateVm();
+        sessionManager.ActiveSession.Messages.Add(
+            new LocalWinAI.Domain.Sessions.ChatMessage(ChatMessageSender.User, "Hi", DateTimeOffset.UtcNow));
+
+        await vm.InitializeAsync();
+
+        vm.Sessions.Should().HaveCount(1);
+        vm.ChatMessages.Should().HaveCount(1);
+        vm.ChatMessages[0].Text.Should().Be("Hi");
+    }
+
+    [Fact]
+    public async Task NewSessionCommand_ClearsMessagesAndAddsSession()
+    {
+        var (vm, _, sessionManager) = CreateVm();
+        await vm.InitializeAsync();
+        vm.ChatMessages.Add(new ObservableChatMessage { Sender = ChatMessageSender.User, Text = "Old message" });
+
+        await vm.NewSessionCommand.ExecuteAsync(null);
+
+        vm.ChatMessages.Should().BeEmpty();
+        sessionManager.AllSessions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task SwitchSessionCommand_LoadsTargetSessionMessages()
+    {
+        var (vm, _, sessionManager) = CreateVm();
+        await vm.InitializeAsync();
+
+        // Add a second session directly so active session stays as session 1.
+        var other = new LocalWinAI.Domain.Sessions.ChatSession();
+        other.Messages.Add(new LocalWinAI.Domain.Sessions.ChatMessage(ChatMessageSender.User, "Other session", DateTimeOffset.UtcNow));
+        sessionManager.AllSessions.Add(other);
+
+        await vm.SwitchSessionCommand.ExecuteAsync(other.Id);
+
+        vm.ChatMessages.Should().HaveCount(1);
+        vm.ChatMessages[0].Text.Should().Be("Other session");
+    }
+
+    [Fact]
+    public async Task DeleteSessionCommand_RemovesSessionFromSidebar()
+    {
+        var (vm, _, sessionManager) = CreateVm();
+        await vm.InitializeAsync();
+        var toDelete = sessionManager.ActiveSession;
+
+        await vm.DeleteSessionCommand.ExecuteAsync(toDelete.Id);
+
+        vm.Sessions.Should().NotContain(s => s.Id == toDelete.Id);
+    }
+
+    [Fact]
+    public void SessionTitleUpdated_Event_UpdatesTitleInSessions()
+    {
+        var (vm, _, sessionManager) = CreateVm();
+        var session = sessionManager.ActiveSession;
+        vm.Sessions.Add(new LocalWinAI.Application.Sessions.ChatSessionSummaryViewModel
+        {
+            Id = session.Id,
+            Title = "Old title",
+            LastUsedAt = session.LastUsedAt
+        });
+        session.Title = "New title";
+
+        sessionManager.RaiseSessionTitleUpdated(session);
+
+        vm.Sessions[0].Title.Should().Be("New title");
     }
 }

--- a/Src/LocalWinAI.Tests/ChatServiceTests.cs
+++ b/Src/LocalWinAI.Tests/ChatServiceTests.cs
@@ -1,19 +1,24 @@
 using FluentAssertions;
 using LocalWinAI.Application;
+using LocalWinAI.Domain.Sessions;
 using LocalWinAI.Tests.Fakes;
 
 namespace LocalWinAI.Tests;
 
 public class ChatServiceTests
 {
-    private static ChatService CreateService(FakeLanguageModelService fake)
-        => new(fake, new FakeUsageTracker());
+    private static (ChatService service, FakeLanguageModelService lm, FakeChatSessionManager sm) CreateService()
+    {
+        var lm = new FakeLanguageModelService { ResponseText = "Fake AI response" };
+        var sm = new FakeChatSessionManager();
+        return (new ChatService(lm, new FakeUsageTracker(), sm), lm, sm);
+    }
 
     [Fact]
     public async Task SendMessageAsync_WhenModelReady_ReturnsGeneratedResponse()
     {
-        var fake = new FakeLanguageModelService { ResponseText = "Hello there!" };
-        var service = CreateService(fake);
+        var (service, lm, _) = CreateService();
+        lm.ResponseText = "Hello there!";
 
         var response = await service.SendMessageAsync("Hi");
 
@@ -23,8 +28,8 @@ public class ChatServiceTests
     [Fact]
     public async Task SendMessageAsync_WhenModelNotReady_ThrowsInvalidOperationException()
     {
-        var fake = new FakeLanguageModelService { IsReady = false };
-        var service = CreateService(fake);
+        var (service, lm, _) = CreateService();
+        lm.IsReady = false;
 
         var act = () => service.SendMessageAsync("Hi");
 
@@ -32,42 +37,77 @@ public class ChatServiceTests
     }
 
     [Fact]
-    public async Task SendMessageAsync_BuildsPromptFromConversationHistory()
+    public async Task SendMessageAsync_WhenModelNotReady_DoesNotAddMessageToSession()
     {
-        var fake = new FakeLanguageModelService { ResponseText = "Response 2" };
-        var service = CreateService(fake);
+        var (service, lm, sm) = CreateService();
+        lm.IsReady = false;
 
-        await service.SendMessageAsync("Message 1");
-        fake.ResponseText = "Response 2";
-        await service.SendMessageAsync("Message 2");
+        try { await service.SendMessageAsync("Hi"); } catch { }
 
-        fake.LastPrompt.Should().Contain("Message 1");
-        fake.LastPrompt.Should().Contain("Message 2");
+        sm.ActiveSession.Messages.Should().BeEmpty();
     }
 
     [Fact]
-    public async Task ClearConversation_ResetsHistorySoNextPromptOnlyContainsNewMessage()
+    public async Task SendMessageAsync_BuildsPromptFromSessionHistory()
     {
-        var fake = new FakeLanguageModelService();
-        var service = CreateService(fake);
-
+        var (service, lm, _) = CreateService();
+        lm.ResponseText = "Response 1";
         await service.SendMessageAsync("Message 1");
-        service.ClearConversation();
+
+        lm.ResponseText = "Response 2";
         await service.SendMessageAsync("Message 2");
 
-        fake.LastPrompt.Should().Be("Message 2");
-        fake.LastPrompt.Should().NotContain("Message 1");
+        lm.LastPrompt.Should().Contain("Message 1");
+        lm.LastPrompt.Should().Contain("Message 2");
     }
 
     [Fact]
     public async Task SendMessageAsync_AddsResponseToHistoryForNextPrompt()
     {
-        var fake = new FakeLanguageModelService { ResponseText = "AI answer" };
-        var service = CreateService(fake);
-
+        var (service, lm, _) = CreateService();
+        lm.ResponseText = "AI answer";
         await service.SendMessageAsync("Question");
+
         await service.SendMessageAsync("Follow-up");
 
-        fake.LastPrompt.Should().Contain("AI answer");
+        lm.LastPrompt.Should().Contain("AI answer");
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_NewActiveSession_PromptsContainOnlyNewSessionMessages()
+    {
+        var (service, lm, sm) = CreateService();
+        lm.ResponseText = "Response 1";
+        await service.SendMessageAsync("Message 1");
+
+        sm.ActiveSession = new ChatSession();
+        lm.ResponseText = "Response 2";
+        await service.SendMessageAsync("Message 2");
+
+        lm.LastPrompt.Should().Be("Message 2");
+        lm.LastPrompt.Should().NotContain("Message 1");
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_PersistsSessionAfterSuccessfulExchange()
+    {
+        var (service, _, sm) = CreateService();
+
+        await service.SendMessageAsync("Hello");
+
+        sm.PersistCallCount.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task SendMessageAsync_AppendsBothMessagesToSession()
+    {
+        var (service, lm, sm) = CreateService();
+        lm.ResponseText = "World";
+
+        await service.SendMessageAsync("Hello");
+
+        sm.ActiveSession.Messages.Should().HaveCount(2);
+        sm.ActiveSession.Messages[0].Text.Should().Be("Hello");
+        sm.ActiveSession.Messages[1].Text.Should().Be("World");
     }
 }

--- a/Src/LocalWinAI.Tests/Fakes/FakeChatService.cs
+++ b/Src/LocalWinAI.Tests/Fakes/FakeChatService.cs
@@ -6,7 +6,6 @@ public sealed class FakeChatService : IChatService
 {
     public string Response { get; set; } = "Fake response";
     public bool ThrowOnSend { get; set; } = false;
-    public bool ConversationCleared { get; private set; }
     public int SendCallCount { get; private set; }
 
     public Task<string> SendMessageAsync(string userMessage, CancellationToken cancellationToken = default)
@@ -16,6 +15,4 @@ public sealed class FakeChatService : IChatService
             throw new InvalidOperationException("Language model is not ready.");
         return Task.FromResult(Response);
     }
-
-    public void ClearConversation() => ConversationCleared = true;
 }

--- a/Src/LocalWinAI.Tests/Fakes/FakeChatSessionManager.cs
+++ b/Src/LocalWinAI.Tests/Fakes/FakeChatSessionManager.cs
@@ -1,0 +1,58 @@
+using LocalWinAI.Application.Sessions;
+using LocalWinAI.Domain.Sessions;
+
+namespace LocalWinAI.Tests.Fakes;
+
+public sealed class FakeChatSessionManager : IChatSessionManager
+{
+    public ChatSession ActiveSession { get; set; } = new();
+    public List<ChatSession> AllSessions { get; } = [];
+    public int PersistCallCount { get; private set; }
+
+    public event EventHandler<ChatSession>? SessionTitleUpdated;
+
+    public Task InitializeAsync(CancellationToken cancellationToken = default)
+    {
+        if (AllSessions.Count == 0)
+            AllSessions.Add(ActiveSession);
+        return Task.CompletedTask;
+    }
+
+    public Task<IReadOnlyList<ChatSession>> GetSessionsAsync()
+        => Task.FromResult<IReadOnlyList<ChatSession>>(AllSessions
+            .Select(s => new ChatSession { Id = s.Id, Title = s.Title, LastUsedAt = s.LastUsedAt, CreatedAt = s.CreatedAt })
+            .ToList());
+
+    public Task<ChatSession> CreateSessionAsync()
+    {
+        var session = new ChatSession();
+        AllSessions.Add(session);
+        ActiveSession = session;
+        return Task.FromResult(session);
+    }
+
+    public Task SwitchToSessionAsync(Guid id)
+    {
+        var session = AllSessions.FirstOrDefault(s => s.Id == id)
+            ?? throw new InvalidOperationException($"Session {id} not found.");
+        ActiveSession = session;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteSessionAsync(Guid id)
+    {
+        AllSessions.RemoveAll(s => s.Id == id);
+        if (ActiveSession.Id == id)
+            ActiveSession = AllSessions.Count > 0 ? AllSessions[^1] : new ChatSession();
+        return Task.CompletedTask;
+    }
+
+    public Task PersistActiveSessionAsync()
+    {
+        PersistCallCount++;
+        return Task.CompletedTask;
+    }
+
+    public void RaiseSessionTitleUpdated(ChatSession session)
+        => SessionTitleUpdated?.Invoke(this, session);
+}

--- a/Src/LocalWinAI.Tests/Fakes/FakeChatSessionRepository.cs
+++ b/Src/LocalWinAI.Tests/Fakes/FakeChatSessionRepository.cs
@@ -1,0 +1,43 @@
+using LocalWinAI.Domain.Sessions;
+
+namespace LocalWinAI.Tests.Fakes;
+
+public sealed class FakeChatSessionRepository : IChatSessionRepository
+{
+    private readonly Dictionary<Guid, ChatSession> _store = [];
+
+    public Task<IReadOnlyList<ChatSession>> GetAllAsync()
+    {
+        IReadOnlyList<ChatSession> result = _store.Values
+            .Select(s => new ChatSession
+            {
+                Id = s.Id,
+                Title = s.Title,
+                CreatedAt = s.CreatedAt,
+                LastUsedAt = s.LastUsedAt
+            })
+            .ToList();
+        return Task.FromResult(result);
+    }
+
+    public Task<ChatSession?> GetAsync(Guid id)
+    {
+        _store.TryGetValue(id, out var session);
+        return Task.FromResult(session);
+    }
+
+    public Task SaveAsync(ChatSession session)
+    {
+        _store[session.Id] = session;
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(Guid id)
+    {
+        _store.Remove(id);
+        return Task.CompletedTask;
+    }
+
+    public int Count => _store.Count;
+    public ChatSession? this[Guid id] => _store.GetValueOrDefault(id);
+}

--- a/Src/LocalWinAI.Tests/Sessions/ChatSessionManagerTests.cs
+++ b/Src/LocalWinAI.Tests/Sessions/ChatSessionManagerTests.cs
@@ -31,8 +31,8 @@ public class ChatSessionManagerTests
         var (manager, repo, _) = Create();
         var old = new ChatSession { LastUsedAt = DateTimeOffset.UtcNow.AddDays(-1) };
         var recent = new ChatSession { LastUsedAt = DateTimeOffset.UtcNow };
-        old.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "old", DateTimeOffset.UtcNow));
-        recent.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "recent", DateTimeOffset.UtcNow));
+        old.AddMessage(new ChatMessage(Domain.ChatMessageSender.User, "old", DateTimeOffset.UtcNow));
+        recent.AddMessage(new ChatMessage(Domain.ChatMessageSender.User, "recent", DateTimeOffset.UtcNow));
         await repo.SaveAsync(old);
         await repo.SaveAsync(recent);
 
@@ -63,7 +63,7 @@ public class ChatSessionManagerTests
         var firstId = manager.ActiveSession.Id;
 
         var second = new ChatSession();
-        second.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "hello", DateTimeOffset.UtcNow));
+        second.AddMessage(new ChatMessage(Domain.ChatMessageSender.User, "hello", DateTimeOffset.UtcNow));
         await repo.SaveAsync(second);
 
         await manager.SwitchToSessionAsync(second.Id);

--- a/Src/LocalWinAI.Tests/Sessions/ChatSessionManagerTests.cs
+++ b/Src/LocalWinAI.Tests/Sessions/ChatSessionManagerTests.cs
@@ -1,0 +1,130 @@
+using FluentAssertions;
+using LocalWinAI.Application.Sessions;
+using LocalWinAI.Domain.Sessions;
+using LocalWinAI.Tests.Fakes;
+
+namespace LocalWinAI.Tests.Sessions;
+
+public class ChatSessionManagerTests
+{
+    private static (ChatSessionManager manager, FakeChatSessionRepository repo, FakeLanguageModelService lm) Create()
+    {
+        var repo = new FakeChatSessionRepository();
+        var lm = new FakeLanguageModelService();
+        return (new ChatSessionManager(repo, lm), repo, lm);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_NoExistingSessions_CreatesNewSession()
+    {
+        var (manager, repo, _) = Create();
+
+        await manager.InitializeAsync();
+
+        manager.ActiveSession.Should().NotBeNull();
+        repo.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task InitializeAsync_ExistingSessions_LoadsMostRecent()
+    {
+        var (manager, repo, _) = Create();
+        var old = new ChatSession { LastUsedAt = DateTimeOffset.UtcNow.AddDays(-1) };
+        var recent = new ChatSession { LastUsedAt = DateTimeOffset.UtcNow };
+        old.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "old", DateTimeOffset.UtcNow));
+        recent.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "recent", DateTimeOffset.UtcNow));
+        await repo.SaveAsync(old);
+        await repo.SaveAsync(recent);
+
+        await manager.InitializeAsync();
+
+        manager.ActiveSession.Id.Should().Be(recent.Id);
+        manager.ActiveSession.Messages.Should().HaveCount(1);
+        manager.ActiveSession.Messages[0].Text.Should().Be("recent");
+    }
+
+    [Fact]
+    public async Task CreateSessionAsync_AddsNewSessionToRepository()
+    {
+        var (manager, repo, _) = Create();
+        await manager.InitializeAsync();
+
+        await manager.CreateSessionAsync();
+
+        repo.Count.Should().Be(2);
+        manager.ActiveSession.Title.Should().Be("New conversation");
+    }
+
+    [Fact]
+    public async Task SwitchToSessionAsync_ChangesActiveSession()
+    {
+        var (manager, repo, _) = Create();
+        await manager.InitializeAsync();
+        var firstId = manager.ActiveSession.Id;
+
+        var second = new ChatSession();
+        second.Messages.Add(new ChatMessage(Domain.ChatMessageSender.User, "hello", DateTimeOffset.UtcNow));
+        await repo.SaveAsync(second);
+
+        await manager.SwitchToSessionAsync(second.Id);
+
+        manager.ActiveSession.Id.Should().Be(second.Id);
+        manager.ActiveSession.Messages.Should().HaveCount(1);
+    }
+
+    [Fact]
+    public async Task DeleteSessionAsync_ActiveSession_SwitchesToRemaining()
+    {
+        var (manager, repo, _) = Create();
+        await manager.InitializeAsync();
+        var first = manager.ActiveSession;
+
+        await manager.CreateSessionAsync();
+        var secondId = manager.ActiveSession.Id;
+
+        await manager.DeleteSessionAsync(secondId);
+
+        manager.ActiveSession.Id.Should().Be(first.Id);
+        repo.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task DeleteSessionAsync_LastSession_CreatesNewSession()
+    {
+        var (manager, repo, _) = Create();
+        await manager.InitializeAsync();
+        var id = manager.ActiveSession.Id;
+
+        await manager.DeleteSessionAsync(id);
+
+        manager.ActiveSession.Should().NotBeNull();
+        manager.ActiveSession.Id.Should().NotBe(id);
+        repo.Count.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task PersistActiveSessionAsync_UpdatesLastUsedAt()
+    {
+        var (manager, repo, _) = Create();
+        await manager.InitializeAsync();
+        var before = manager.ActiveSession.LastUsedAt;
+        await Task.Delay(10);
+
+        await manager.PersistActiveSessionAsync();
+
+        var saved = repo[manager.ActiveSession.Id];
+        saved!.LastUsedAt.Should().BeAfter(before);
+    }
+
+    [Fact]
+    public async Task GetSessionsAsync_ReturnsAllSessionMetadata()
+    {
+        var (manager, _, _) = Create();
+        await manager.InitializeAsync();
+        await manager.CreateSessionAsync();
+
+        var sessions = await manager.GetSessionsAsync();
+
+        sessions.Should().HaveCount(2);
+    }
+}


### PR DESCRIPTION
Implements persistent chat sessions so conversations survive app restarts and can be managed from a sidebar. Closes #4.

## Summary

- **Domain** — adds `ChatSession`, `ChatMessage`, and `IChatSessionRepository` as the persistence contract.
- **Application** — adds `IChatSessionManager` / `ChatSessionManager` to track the active session, auto-generate titles via the language model after the first exchange, and expose `NewSessionCommand`, `SwitchSessionCommand`, and `DeleteSessionCommand` on `ChatPageViewModel`. Removes `ClearConversationCommand`.
- **Infrastructure** — adds `ChatSessionRepository` which serialises sessions to `%LocalAppData%\LocalWinAI\sessions\` (one JSON file per session + a lightweight `index.json`).
- **UI** — restructures `ChatPage` with a `SplitView`: left pane is a session sidebar (sorted by last-used, with New/Delete actions), right pane is the existing chat area. Removes the Clear button.
- **Bug fix** — session-switch no longer drops an in-flight request/response.

## Test plan

- [x] Launch the app — most-recent session loads automatically; sending a message persists it to disk.
- [x] Click **+ New Session** — blank chat opens; previous session is still listed in the sidebar.
- [x] Close and reopen the app — all sessions are restored; the last-used session is active.
- [x] Switch sessions — the chat area repopulates with the selected session's history.
- [x] Delete a session — app switches to the next available session (or creates a new one if the list is empty).
- [x] First AI reply in a new session — title auto-updates in the sidebar (or falls back to a 50-char truncation).
- [x] `ChatSessionManagerTests`, `ChatServiceTests`, `ChatPageViewModelTests` all pass.
